### PR TITLE
Chore: Update dependency packages `fastapi` and `keyring`

### DIFF
--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,4 +1,4 @@
 build<2
 bump2version<2
-keyring<25
+keyring<26
 twine<6

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name="imagecast",
       ],
       extras_require={
           "service": [
-              "fastapi<0.110",
+              "fastapi<0.111",
               "uvicorn<0.30",
           ],
       },


### PR DESCRIPTION
Bundle GH-41 and GH-45.