### PR TITLE
Maintenance: Improve software tests. Fix HTTP API. Use docopt-ng and pydantic 1.x. No Python 3.7.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04 ]
-        python-version: [ "3.7", "3.12" ]
+        python-version: [ "3.8", "3.12" ]
 
     name: Python ${{ matrix.python-version }} on OS ${{ matrix.os }}
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ in progress
 ===========
 - Added software tests for HTTP API and CLI
 - Fixed HTTP API by downgrading to pydantic 1.x
+- Removed support for Python 3.7
 
 2023-12-20 0.6.0
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Imagecast changelog
 
 in progress
 ===========
-
+- Added software tests for HTTP API and CLI
 
 2023-12-20 0.6.0
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Imagecast changelog
 in progress
 ===========
 - Added software tests for HTTP API and CLI
+- Fixed HTTP API by downgrading to pydantic 1.x
 
 2023-12-20 0.6.0
 ================

--- a/README.rst
+++ b/README.rst
@@ -138,6 +138,10 @@ Example::
 
         imagecast service --allowed-hosts=unsplash.com,media.example.org
 
+    By default, no host will be allowed. If you really need to enable access
+    to all upstream hosts, use ``--allowed-hosts=*``. All host names must be
+    listed explicitly, wildcard notations like ``*.iana.org`` are not permitted.
+
 
 **************
 Other projects

--- a/imagecast/api.py
+++ b/imagecast/api.py
@@ -2,9 +2,10 @@
 # (c) 2020-2021 Andreas Motl <andreas@terkin.org>
 # License: GNU Affero General Public License, Version 3
 import logging
+import sys
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import List, Annotated
+from typing import List
 from urllib.parse import urlparse
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -15,6 +16,12 @@ from starlette.status import HTTP_403_FORBIDDEN
 
 from imagecast import __appname__, __version__
 from imagecast.core import process
+
+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+else:
+    from typing import Annotated
 
 
 # https://fastapi.tiangolo.com/advanced/settings/

--- a/imagecast/cli.py
+++ b/imagecast/cli.py
@@ -20,7 +20,7 @@ def run():
     Imagecast modifies images, optionally serving them via HTTP API.
 
     Usage:
-      imagecast --uri=<uri> [--element=] [--monochrome=<threshold>] [--grayscale] [--width=<width>] [--height=<height>] [--crop=<cropbox>] [--display] [--format=<format>] [--dpi=<dpi>] [--save=<save>]
+      imagecast --uri=<uri> [--element=] [--monochrome=<threshold>] [--grayscale] [--width=<width>] [--height=<height>] [--crop=<cropbox>] [--display] [--format=<format>] [--dpi=<dpi>] [--save=<save>] [--debug]
       imagecast service [--listen=<listen>] [--allowed-hosts=<allowed-hosts>] [--reload]
       imagecast --version
       imagecast (-h | --help)

--- a/imagecast/core.py
+++ b/imagecast/core.py
@@ -2,11 +2,15 @@
 # (c) 2020-2021 Andreas Motl <andreas@hiveeyes.org>
 # License: GNU Affero General Public License, Version 3
 import io
+import logging
 import tempfile
 
 import requests
 from PIL import Image
 from requests_cache import CachedSession
+
+
+logger = logging.getLogger(__name__)
 
 
 class ImageEngine:
@@ -98,6 +102,9 @@ class ImageEngine:
 
 def process(options):
     ie = ImageEngine(cache_ttl=options.cache_ttl)
+
+    logger.info(f"Acquiring image from {options.uri}")
+
     ie.acquire(options.uri, options.element)
     ie.read()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 minversion = "2.0"
 addopts = "-rsfEX -p pytester --strict-markers --verbosity=3"
 log_level = "DEBUG"
+log_cli_level = "DEBUG"
 testpaths = ["test"]
 xfail_strict = true
 markers = [

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
+httpx
 pytest<9

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(name="imagecast",
       },
       zip_safe=False,
       install_requires=[
-          "docopt>=0.6,<1",
+          "docopt-ng>=0.6,<1",
           "munch>=2.3,<5",
           "Pillow>=8,<11",
           "playwright<1.44",

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(name="imagecast",
       extras_require={
           "service": [
               "fastapi<0.111",
+              "pydantic<2",
               "uvicorn<0.30",
           ],
       },

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(name="imagecast",
       },
       zip_safe=False,
       install_requires=[
+          "typing-extensions<5; python_version<'3.9'",
           "docopt-ng>=0.6,<1",
           "munch>=2.3,<5",
           "Pillow>=8,<11",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(name="imagecast",
       classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -26,7 +26,7 @@ def test_api_index():
     assert re.match(r".*<title>imagecast [\d.]+</title>.*", response.text, re.DOTALL)
 
 
-def test_api_unsplash_converge():
+def test_api_unsplash_converge(caplog):
     """
     Verify image management works.
     """
@@ -37,11 +37,16 @@ def test_api_unsplash_converge():
         "width": "640",
     }
     response = client.get("/", params=query_params)
+
+    # Verify log output.
+    assert "Acquiring image from https://unsplash.com/photos/WvdKljW55rM/download?force=true" in caplog.messages
+
+    # Verify content output.
     assert response.status_code == 200
     assert response.content.startswith(b"\xff\xd8\xff\xe0\x00\x10JFIF")
 
 
-def test_api_html_acquire():
+def test_api_html_acquire(caplog):
     """
     Verify HTML DOM element acquisition works.
     """
@@ -50,5 +55,10 @@ def test_api_html_acquire():
         "element": "#logo",
     }
     response = client.get("/", params=query_params)
+
+    # Verify log output.
+    assert "Acquiring image from https://www.iana.org/help/example-domains" in caplog.messages
+
+    # Verify content output.
     assert response.status_code == 200
     assert response.content.startswith(b"\x89PNG\r\n\x1a")

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,54 @@
+import re
+
+from fastapi.testclient import TestClient
+
+from imagecast.api import app, Settings, get_settings
+
+client = TestClient(app)
+
+
+def get_settings_override():
+    """
+    Override settings to permit access to iana.org and unsplash.com.
+    """
+    return Settings(allowed_hosts=["www.iana.org", "unsplash.com"])
+
+
+app.dependency_overrides[get_settings] = get_settings_override
+
+
+def test_api_index():
+    """
+    Verify HTML index page rendering works.
+    """
+    response = client.get("/")
+    assert response.status_code == 200
+    assert re.match(r".*<title>imagecast [\d.]+</title>.*", response.text, re.DOTALL)
+
+
+def test_api_unsplash_converge():
+    """
+    Verify image management works.
+    """
+    query_params = {
+        "uri": "https://unsplash.com/photos/WvdKljW55rM/download?force=true",
+        "monochrome": "80",
+        "crop": "850,1925,-950,-900",
+        "width": "640",
+    }
+    response = client.get("/", params=query_params)
+    assert response.status_code == 200
+    assert response.content.startswith(b"\xff\xd8\xff\xe0\x00\x10JFIF")
+
+
+def test_api_html_acquire():
+    """
+    Verify HTML DOM element acquisition works.
+    """
+    query_params = {
+        "uri": "https://www.iana.org/help/example-domains",
+        "element": "#logo",
+    }
+    response = client.get("/", params=query_params)
+    assert response.status_code == 200
+    assert response.content.startswith(b"\x89PNG\r\n\x1a")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -36,7 +36,7 @@ def test_cli_unsplash_converge(tmp_path, caplog):
     imagecast.cli.run()
 
     # Verify log output.
-    assert "Starting new HTTPS connection (1): unsplash.com:443" in caplog.messages
+    assert "Acquiring image from https://unsplash.com/photos/WvdKljW55rM/download?force=true" in caplog.messages
 
     # Verify content output.
     payload = output_file.read_bytes()
@@ -52,7 +52,7 @@ def test_cli_html_acquire(tmp_path, caplog):
     imagecast.cli.run()
 
     # Verify log output.
-    assert "Starting new HTTPS connection (1): www.iana.org:443" in caplog.messages
+    assert "Acquiring image from https://www.iana.org/help/example-domains" in caplog.messages
 
     # Verify content output.
     payload = output_file.read_bytes()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,59 @@
+import re
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+import imagecast.cli
+
+
+def set_command(options):
+    command = f'imagecast {options}'
+    sys.argv = shlex.split(command)
+
+
+def test_cli_version(capsys):
+    """
+    Invoke `imagecast --version`.
+    """
+    # Run command and capture output.
+    set_command("--version")
+    with pytest.raises(SystemExit):
+        imagecast.cli.run()
+    captured = capsys.readouterr()
+
+    # Verify output.
+    assert re.match(r"imagecast [\d.]+", captured.out)
+
+
+def test_cli_unsplash_converge(tmp_path, caplog):
+    """
+    Verify image management works.
+    """
+    output_file: Path = tmp_path / "imagecast-unsplash.png"
+    set_command(f'--uri="https://unsplash.com/photos/WvdKljW55rM/download?force=true" --monochrome=80 --crop=850,1925,-950,-900 --width=640 --save="{output_file}" --debug')
+    imagecast.cli.run()
+
+    # Verify log output.
+    assert "Starting new HTTPS connection (1): unsplash.com:443" in caplog.messages
+
+    # Verify content output.
+    payload = output_file.read_bytes()
+    assert payload.startswith(b"\x89PNG\r\n\x1a\n\x00")
+
+
+def test_cli_html_acquire(tmp_path, caplog):
+    """
+    Verify HTML DOM element acquisition works.
+    """
+    output_file: Path = tmp_path / "imagecast-iana-logo.png"
+    set_command(f'--uri="https://www.iana.org/help/example-domains" --element="#logo" --save="{output_file}" --debug')
+    imagecast.cli.run()
+
+    # Verify log output.
+    assert "Starting new HTTPS connection (1): www.iana.org:443" in caplog.messages
+
+    # Verify content output.
+    payload = output_file.read_bytes()
+    assert payload.startswith(b"\x89PNG\r\n\x1a\n\x00")


### PR DESCRIPTION
- Add software tests for HTTP API and CLI
- Dependencies: Use docopt-ng
- README: Improve section about --allowed-hosts
- Fix HTTP API by downgrading to pydantic 1.x
- Remove support for Python 3.7