### PR TITLE
Upgrade to pydantic-settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ in progress
 - Added software tests for HTTP API and CLI
 - Fixed HTTP API by downgrading to pydantic 1.x
 - Removed support for Python 3.7
+- Upgrade to pydantic-settings
 
 2023-12-20 0.6.0
 ================

--- a/imagecast/api.py
+++ b/imagecast/api.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse, PlainTextResponse, Response
 from PIL import Image
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from starlette.status import HTTP_403_FORBIDDEN
 
 from imagecast import __appname__, __version__

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(name="imagecast",
       extras_require={
           "service": [
               "fastapi<0.111",
-              "pydantic<2",
+              "pydantic-settings<3",
               "uvicorn<0.30",
           ],
       },


### PR DESCRIPTION
## Problem
```
pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package.

See https://docs.pydantic.dev/2.7/migration/#basesettings-has-moved-to-pydantic-settings for more details.
```